### PR TITLE
trello helper handles cached values properly

### DIFF
--- a/serviceHelpers/trello.py
+++ b/serviceHelpers/trello.py
@@ -23,20 +23,32 @@ class trello():
 
     def find_trello_card(self, regex) -> dict:
         "uses regexes to search name and description of cached / fetched cards. Returns the first it finds."
-        cards = self.fetch_trello_cards() if self.dirty_cache else self._cached_cards
-        
-        for card in cards:
-            if re.search(regex,card["name"]) or re.search(regex,card["desc"]):
-                return card
-        return 
+        cards = (
+            self.fetch_trello_cards()
+            if self.dirty_cache
+            else list(self._cached_cards.values())
+        )
 
+        for card in cards:
+            card:dict
+            try:
+                if re.search(regex, card.get("name","")) or re.search(regex, card.get("desc","")):
+                    return card
+
+            except (Exception,) as err:
+                lo.error(
+                    "Failed to parse trello card's title & description when looking for matches, %s ",
+                    err,
+                )
+        return
     def find_trello_cards(self,regex):
         "uses regexes to search name and description of cached / fetched cards. Returns all cards found."
 
-        cards = self.fetch_trello_cards() if self.dirty_cache else self._cached_cards
+        cards = self.fetch_trello_cards() if self.dirty_cache else list(self._cached_cards.values())
         foundCards = []
         for card in cards: 
-            if re.search(regex,card["name"]) or re.search(regex,card["desc"]):
+            card:dict
+            if re.search(regex,card.get("name","")) or re.search(regex,card.get("desc","")):
                 foundCards.append(card)
         return foundCards
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ packages = setuptools.find_packages()
 
 setup(
     name="hex-helpers",
-    version="2.7.4",
+    version="2.7.5",
     description="A series of light helpers for `freshdesk`,`gmail`,`habitica`,`hue lights`,`jira`,`slack`,`trello`",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/test_trello_functions.py
+++ b/tests/test_trello_functions.py
@@ -93,6 +93,24 @@ def test_get_list():
     assert(len(cards) == 3 )
 
 
+def test_find_cards():
+    helper = trello("none","none","none")
+    helper._cached_cards = {
+        "id_1":{"id":"id_1","name":"match","desc":""},
+        "id_2":{"id":"id_2","name":"main","desc":"match"},
+        "id_3":{"id":"id_3","name":"skip","desc":""},
+        "id_4":{"id":"id_4","name":"main","desc":"different"},
+        "id_5":{"id":"id_5","name":"fancy"},
+        "id_6":{"id":"id_6","name":"jam","desc":"hello"},
+        "id_7":{"id":"id_7","name":"train","desc":"ignore me"},
+        
+    }
+    helper.dirty_cache = False
+    found = helper.find_trello_cards("match")
+    assert isinstance(found,list)
+    assert len(found) == 2
+
+
 def test_create_card_at_correct_position():
     helper = trello(TEST_BOARD_ID,os.environ["TRELLO_KEY"],os.environ["TRELLO_TOKEN"])
     card = helper.create_card("TEST CARD, PLEASE IGNORE",TEST_LIST_ID,"A temporary card that should get deleted",position=0)


### PR DESCRIPTION
### **What**
Convert cached dict into a list when being fed into the "find" method

### **Why**
Trello helper was feeding a dict of cards into the "find" method, not a list as it expected.
This was causing crashes.

### **Testing** 

- [X] Unit testing  
- [X] Functional test 
